### PR TITLE
Stop animation when exiting lockscreen.

### DIFF
--- a/patch/unified_diff.patch
+++ b/patch/unified_diff.patch
@@ -76,6 +76,13 @@ diff -rupN original/usr/share/lipstick-jolla-home-qt5/lockscreen/LockEventItem.q
 +    property alias color: rectangle.color
 +    spacing: Theme.paddingSmall
 +
++    Connections {
++        target: lockScreen
++        onLockedChanged: {
++           if (!lockScreen.locked) scrollAnimation.stop()
++        }
++    }
++
 +    Rectangle 
 +    {
 +        id: rectangle


### PR DESCRIPTION
Without doing this the whole phone slows down until the animation has looped 3 times. This mostly noticeable when trying to play games or scrolling.
